### PR TITLE
Fix ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 import javascript from "@eslint/js";
+import prettier from "eslint-config-prettier";
 import astro from "eslint-plugin-astro";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactJSXRuntime from "eslint-plugin-react/configs/jsx-runtime.js";
@@ -6,6 +7,7 @@ import typescript from "typescript-eslint";
 
 export default [
     javascript.configs.recommended,
+    prettier,
     ...typescript.configs.recommended,
     ...typescript.configs.stylistic,
     ...astro.configs.recommended,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,17 +7,8 @@ import globals from "globals";
 import typescript from "typescript-eslint";
 
 export default [
-    js.configs.recommended,
-    ...typescript.configs.recommendedTypeChecked,
-    ...typescript.configs.stylisticTypeChecked,
-    {
-        languageOptions: {
-            parserOptions: {
-                project: true,
-                tsconfigRootDir: import.meta.dirname,
-            },
-        },
-    },
+    ...typescript.configs.recommended,
+    ...typescript.configs.stylistic,
     ...astro.configs.recommended,
     {
         ...reactRecommended,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,8 +2,6 @@ import javascript from "@eslint/js";
 import astro from "eslint-plugin-astro";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactJSXRuntime from "eslint-plugin-react/configs/jsx-runtime.js";
-import reactRecommended from "eslint-plugin-react/configs/recommended.js";
-import globals from "globals";
 import typescript from "typescript-eslint";
 
 export default [
@@ -11,36 +9,20 @@ export default [
     ...typescript.configs.recommended,
     ...typescript.configs.stylistic,
     ...astro.configs.recommended,
+    reactJSXRuntime,
     {
-        ...reactRecommended,
-
-        files: ["**/*.{jsx,tsx}"],
-        languageOptions: {
-            ...reactRecommended.languageOptions,
-
-            globals: {
-                ...globals.serviceworker,
-                ...globals.browser,
-            },
-        },
+        files: ["**/*.tsx"],
         rules: {
-            ...reactRecommended.rules,
-
             "react/no-unknown-property": "error",
         },
-    },
-    {
-        ...reactJSXRuntime,
-
         settings: {
-            ...reactJSXRuntime.settings,
-
             react: {
                 version: "detect",
             },
         },
     },
     {
+        rules: reactHooks.configs.recommended.rules,
         plugins: {
             "react-hooks": reactHooks,
         },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,4 @@
-import js from "@eslint/js";
+import javascript from "@eslint/js";
 import astro from "eslint-plugin-astro";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactJSXRuntime from "eslint-plugin-react/configs/jsx-runtime.js";
@@ -7,6 +7,7 @@ import globals from "globals";
 import typescript from "typescript-eslint";
 
 export default [
+    javascript.configs.recommended,
     ...typescript.configs.recommended,
     ...typescript.configs.stylistic,
     ...astro.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -25,14 +25,13 @@
         "typescript": "^5.5.2"
     },
     "devDependencies": {
-        "@eslint/eslintrc": "^3.1.0",
         "@eslint/js": "^9.6.0",
         "@fontsource/roboto": "^5.0.13",
         "@ianvs/prettier-plugin-sort-imports": "^4.3.0",
         "@tailwindcss/typography": "^0.5.13",
         "@types/eslint__js": "^8.42.3",
         "daisyui": "^4.12.10",
-        "eslint": "^8.57.0",
+        "eslint": "^9.7.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-astro": "^1.2.2",
         "eslint-plugin-react": "^7.34.3",
@@ -42,6 +41,6 @@
         "prettier-plugin-sort-json": "^4.0.0",
         "prettier-plugin-tailwindcss": "^0.6.5",
         "theme-change": "^2.5.0",
-        "typescript-eslint": "^7.14.1"
+        "typescript-eslint": "^8.0.0-alpha.52"
     }
 }


### PR DESCRIPTION
When I had setup ESLint initially, I hadn't realised that React and Astro code alike were not being linted. In hopes of completing the current feature, I aimed to resolve this promptly afterwards and stopped midway. This PR should remedy the ESLint mishap and allow ESLint 9's flat configuration format to be used and code to be linted (which is good).
